### PR TITLE
Add socket-channel in header to execute websocket in a custom channel

### DIFF
--- a/lib/src/models/broadcast_model.dart
+++ b/lib/src/models/broadcast_model.dart
@@ -3,26 +3,26 @@ import 'dart:convert';
 import 'package:json_rest_server/src/core/enum/broadcast_type.dart';
 
 class BroadcastModel {
-  final String method;
+  final String channel;
   final String table;
   final Map<String, dynamic> payload;
   final BroadCastType? broadCastType;
   DateTime? sentAt;
   BroadcastModel(
-      {required this.method,
+      {required this.channel,
       required this.table,
       required this.payload,
       required this.broadCastType,
       this.sentAt});
 
   BroadcastModel copyWith({
-    String? method,
+    String? channel,
     String? table,
     Map<String, dynamic>? payload,
     BroadCastType? broadCastType,
   }) {
     return BroadcastModel(
-      method: method ?? this.method,
+      channel: channel ?? this.channel,
       table: table ?? this.table,
       payload: payload ?? this.payload,
       broadCastType: broadCastType ?? this.broadCastType,
@@ -31,7 +31,7 @@ class BroadcastModel {
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
-      'method': method,
+      'channel': channel,
       'table': table,
       'payload': payload,
       'broadCastType': broadCastType?.name,
@@ -41,7 +41,7 @@ class BroadcastModel {
 
   factory BroadcastModel.fromMap(Map<String, dynamic> map) {
     return BroadcastModel(
-      method: map['method'] as String,
+      channel: map['channel'] as String,
       table: map['table'] as String,
       payload:
           Map<String, dynamic>.from(map['payload'] as Map<String, dynamic>),
@@ -61,15 +61,15 @@ class BroadcastModel {
 
   @override
   String toString() {
-    return 'BroadcastModel(method: $method, table: $table, payload: $payload, broadCastType: $broadCastType)';
+    return 'BroadcastModel(channel: $channel, table: $table, payload: $payload, broadCastType: $broadCastType)';
   }
 
   factory BroadcastModel.fromRequest(
-      {required String method,
+      {required String channel,
       required String table,
       required Map<String, dynamic> data}) {
     return BroadcastModel(
-      method: method,
+      channel: channel,
       table: table,
       payload: data,
       broadCastType: null,

--- a/lib/src/server/handler_request.dart
+++ b/lib/src/server/handler_request.dart
@@ -72,11 +72,14 @@ class HandlerRequest {
         );
       } else {
         final segments = request.url.pathSegments;
+        final channel = (request.headers.containsKey('socket-channel'))
+            ? request.headers['socket-channel']
+            : request.method;
         final String table = segments.first;
         broadcast.execute(
           providers: config.broadcastProvider,
           broadcast: BroadcastModel.fromRequest(
-            method: request.method,
+            channel: channel ?? request.method,
             table: table,
             data: mapResponse,
           ),


### PR DESCRIPTION
Socket server improvements.
Now you can send a specific socket channel in the HTTP header (**socket-channel**) and the socket will send to each client logged into this specific channel the object that was affected in the

POST, PUT, PATCH, DELETE

For example, if you are listening to the 'new-users' channel somewhere in your application, and someone triggers a POST with that channel in the header, all clients will receive that new user in the payload, as well as being able to check the table name that was affected.

```json
{
  "channel": "new-users",
  "table": "users",
  "payload": {
    "id": 23,
    "name": "JOHN DUE",
    "email": "johndue@jhon.com"
  },
  "broadCastType": "socket",
  "sentAt": "2023-11-16T18:52:42.274975"
}
```