### PR TITLE
Adição de parametros para a paginação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.7.0
+- Feat: Add pageable parameters on pagination
+- break change: format json from list to object with pagination
+
+## 1.6.0
+- Feat: Add socket-channel in header to execute websocket in a custom channel 
+  
 ## 1.6.0
 - Feat: Add socket-channel in header to execute websocket in a custom channel 
 

--- a/README.en.md
+++ b/README.en.md
@@ -98,6 +98,38 @@ DELETE /products/1                                  -> Delete a product based on
 
 In the example folder there is a postman file with all the examples above
 
+## Pagination
+
+The response can be paginated by passing the `page` and `limit` parameters in the URL. It returns an object with the following characteristics.
+
+**Parameters**
+
+- `current_page`: The number of the current page.
+- `items_per_page`: The number of items per page.
+- `total_pages`: The total number of pages.
+- `total_items`: The total number of items.
+- `data`: An array containing the data of the current page.
+
+**Example**
+
+`http://localhost:3000/users?page=1&limit=5`
+
+```json
+{
+  "current_page": 1,
+  "items_per_page": 5,
+  "total_pages": 10,
+  "total_items": 50,
+  "data": [
+    {
+      "id": "any",
+      "name": "any name"
+    },
+    ...
+  ]
+}
+
+
 ## Authentication
 
 Json Rest Server already have all the auth process using JWT.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,42 @@ DELETE /products/1                                  -> Deletar um produto
 Na pasta exemplos existe um arquivo postman com todos os exemplos mencionados acima
 
 
+## Paginação
+
+A resposta pode ser paginada passando os parâmetros `page` e `limit` na URL.
+retorna um objeto com as seguintes caracteristicas. 
+
+
+**Parametros**
+
+- `current_page`: O número da página atual.
+- `items_per_page`: O número de itens por página.
+- `total_pages`: O total de páginas.
+- `total_items`: O total de itens.
+- `data`: Um array contendo os dados da página atual.
+
+
+**exemplo**
+
+`http://localhost:3000/users?page=1&limit=5`
+
+```
+{
+  "current_page": 1,
+  "items_per_page": 5,
+  "total_pages": 10,
+  "total_items": 50,
+  "data": [
+    {
+      id: 'any',
+      name: 'any name'
+    },
+    ...
+  ]
+}
+```
+
+
 ## Autenticação
 
 Json Rest Server já vem com todo o processo de autenticação por meio de JWT.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -115,6 +115,42 @@ DELETE /products/1                                  -> Deletar um produto
 Na pasta exemplos existe um arquivo postman com todos os exemplos mencionados acima
 
 
+## Paginação
+
+A resposta pode ser paginada passando os parâmetros `page` e `limit` na URL.
+retorna um objeto com as seguintes caracteristicas. 
+
+
+**Parametros**
+
+- `current_page`: O número da página atual.
+- `items_per_page`: O número de itens por página.
+- `total_pages`: O total de páginas.
+- `total_items`: O total de itens.
+- `data`: Um array contendo os dados da página atual.
+
+
+**exemplo**
+
+`http://localhost:3000/users?page=1&limit=5`
+
+```
+{
+  "current_page": 1,
+  "items_per_page": 5,
+  "total_pages": 10,
+  "total_items": 50,
+  "data": [
+    {
+      id: 'any',
+      name: 'any name'
+    },
+    ...
+  ]
+}
+```
+
+
 ## Autenticação
 
 Json Rest Server já vem com todo o processo de autenticação por meio de JWT.

--- a/lib/src/server/handlers/get_handler.dart
+++ b/lib/src/server/handlers/get_handler.dart
@@ -95,7 +95,24 @@ class GetHandler {
     var params = {...queryParameters};
 
     if (params.containsKey('page')) {
+      final currentPage = params['page'];
+      final perPage = params['limit'];
+      final totalItems = tableData.length;
+      final totalPages =
+          (totalItems / (num.tryParse(perPage ?? '') ?? 0)).toDouble().ceil();
+
       tableData = _processPagination(tableData, queryParameters, headers);
+      return Response(
+        200,
+        body: jsonEncode({
+          'current_page': currentPage ?? '',
+          'items_per_page': perPage ?? '',
+          'total_pages': totalPages,
+          'total_items': totalItems,
+          'data': (tableData),
+        }),
+        headers: _jsonHelper.jsonReturn,
+      );
     } else {
       if (params.isNotEmpty) {
         tableData = _filterData(tableData, queryParameters, headers);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_rest_server
 description: A RESTful server based on JSON With this package you can have a fully functional RESTful server with auth, pagination and all the necessaries services do build an application
-version: 1.6.0
+version: 1.7.0
 repository: https://github.com/rodrigorahman/json_rest_server
 issue_tracker: https://github.com/rodrigorahman/json_rest_server/issues
 
@@ -29,4 +29,3 @@ executables:
   json_rest_server: json_rest_server
   jsonRestServer: json_rest_server
   jrs: json_rest_server
-


### PR DESCRIPTION
com essa implementação você pode paginar a resposta passando os parâmetros page e limit na URL. A resposta será um objeto com as seguintes características:
- current_page: O número da página atual.
- items_per_page: O número de itens por página.
- total_pages: O número total de páginas.
- total_items: O número total de itens.
- data: Um array contendo os dados da página atual.
Por exemplo, se você acessar a URL http://localhost:3000/users?page=1&limit=5, a resposta será um objeto JSON que inclui a página atual, o número de itens por página, o total de páginas, o total de itens e os dados da página atual.

```{
  "current_page": 1,
  "items_per_page": 5,
  "total_pages": 10,
  "total_items": 50,
  "data": [
    {
      "id": "any",
      "name": "any name"
    },
    ...
  ]
}```

Os dados da página atual são um array de objetos, cada um representando um usuário. Isso facilita a navegação pelos dados retornados pela API, especialmente quando há uma grande quantidade de dados a serem recuperados.
