### PR TITLE
Customização dos campos de Auth, passando os campos e os respectivos tipos de dado + Documentação no README

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,9 +39,9 @@
             "program": "${workspaceFolder}/bin/json_rest_server.dart",
             "args": ["run"],
             "toolArgs": [
-                "--define=debugPath=F:/flutter_experience/2024_01/projeto/projeto_gravacao/fe_lab_clinicas_api/"
+                "--define=debugPath=/Users/adilsonjunior/w2o/apps/pbs/pbs_api/"
             ]
         },
-        
+
     ]
 }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ auth:
         type: int
     - celular:
         type: string
-    - peso:
+    - nota:
         type: double
 
 ```
@@ -198,9 +198,21 @@ auth:
 Para realizar o login você precisa fazer um post para a url ex: http://localhost:8080/auth com o body:
 
 ```json
+// Exemplo de request padrão.
 {
     "email": "rodrigorahman@academiadoflutter.com.br",
     "password": "123"
+}
+```
+
+Caso você tenha configurado o authFields para personalizar os campos de login, devem ser enviados os campos da forma como foram definidos no config.yaml.
+
+```json
+// Exemplo de request customizada com authFields.
+{
+    "matricula": 102030,
+    "celular": "+5535988881234",
+    "nota": 8.5
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Json Rest Server is a RESTful server based on JSON
 
 [![Json Rest Server](https://github.com/rodrigorahman/json_rest_server/actions/workflows/dart.yml/badge.svg)](https://github.com/rodrigorahman/json_rest_server/actions/workflows/dart.yml)
 
-# Json Rest Server 
+# Json Rest Server
 
 Um RESTful server baseado em JSON
 
@@ -43,7 +43,7 @@ idType( uuid | int ) -> Agora o json_rest_server suporta que os ids sejam ou int
 
 ## Comandos
 
-**ATENÇÃO**: 
+**ATENÇÃO**:
 O executável padrão do projeto é json_rest_server porém você também pode utilizar **jsonRestServer** ou somente **jrs** facilitando assim a digitação ;-)
 
 **Atualizando**:
@@ -135,17 +135,29 @@ auth:
   urlSkip:
     - path_sem_autenticacao:
         method: metodo http (post,get,put,patch ou delete)
+  authFields:
+    - matricula:
+        type: int
+    - celular:
+        type: string
 ```
 
 Descrição das tags:
 
 ```yaml
-jwtSecret -> Chave de autenticação do jwt (essa chave é importante para validação do token)
-jwtExpire -> Tempo de expiração do token em segundos
-enableAdm -> Se habilitado o json_rest_server vai permitir somente requisições de POST, PUT, DELETE para usuários administradores
+jwtSecret -> Chave de autenticação do jwt (essa chave é importante para validação do token).
+
+jwtExpire -> Tempo de expiração do token em segundos.
+
+enableAdm -> Se habilitado o json_rest_server vai permitir somente requisições de POST, PUT, DELETE para usuários administradores.
+
 urlUserPermission -> Quando habilitado o enableADM você pode permitir que um usuário simples faça as requisições de POST, PUT, DELETE colocando a url aqui.
-unauthorizedStatusCode -> Status de retorno para acesso negado
-urlSkip -> Coloque aqui as urls e métodos http que você não que seja verificada a autenticação do usuário (paths não autenticados)
+
+unauthorizedStatusCode -> Status de retorno para acesso negado.
+
+urlSkip -> Coloque aqui as urls e métodos http que você não que seja verificada a autenticação do usuário (paths não autenticados).
+
+authFields -> Coloque aqui os campos que serão usados na autenticação e seus respectivos tipos para customizar o login.
 ```
 
 **Exemplo**
@@ -153,6 +165,12 @@ urlSkip -> Coloque aqui as urls e métodos http que você não que seja verifica
 No exemplo abaixo, não será verificada a autenticação para o path /users no método post (Cadastro de um novo usuário).
 
 Agora o segundo path **/products/{\*}** você deve ter achado estranho o parâmetro **{\*}**, mas ele é um coringa de acesso, pois, todos os paths configurados no database.json respondem a busca de dados por id, na url ex: **/producs/1** e precisavamos ignorar o id para identificar a url, sendo assim criamos o coringa **{\*}** deixando esse pedaço da url dinâmico permitindo que uma url **/products/1** possa ser acessada sem autenticação.
+
+O parâmetro authFields é **opcional**, e nele deve ser passado os campos que serão usados para fazer a autenticação. É necessário inserir **nome** do campo e o **tipo de dado** como no exemplo abaixo.
+
+Tipos permitidos no authFields -> "**string**", "**int**" ou "**double**"
+
+**Obs:** Caso o parâmetro authFields não seja definido no *config.yaml*, o Json Rest Server manterá a autenticação padrão, que utiliza **"email"** e **"password"**, ambos como string.
 
 ```json
 auth:
@@ -164,6 +182,13 @@ auth:
         method: post
     - /products/{*}:
         method: get
+  authFields:
+    - matricula:
+        type: int
+    - celular:
+        type: string
+    - peso:
+        type: double
 
 ```
 
@@ -291,7 +316,7 @@ O Json Rest Server vai substituir o valor de #userAuthRef pelo id do usuário lo
 
 Para fazer a busca por um campo com o ID do usuário logado, você precisa enviar no filtro a tag #userAuthRef, o Json Rest Server vai substituir o valor pelo id do usuário logado ex:
 
-`http://localhost:8080/products?user_id=#userAuthRef` 
+`http://localhost:8080/products?user_id=#userAuthRef`
 
 O JRS vai substituir a tag #userAuthRef pelo o id do usuário logado e realizar o filtro no campo user_id
 
@@ -303,15 +328,15 @@ Inicialmente o sistema está compatível com o envio para ***socket e slack***
 
 ```yaml
 
-enableSocket: true 
+enableSocket: true
 #Indica se você quer que inicie um servidor de socket junto com o servidor rest (true/false)
 socketPort: 8081
 #Indica a porta de acesso do socket padrão (Websocket não utiliza essa porta):  8081
 broadcastProvider: socket
 #Indica pra qual tipo de broadcast ele quer enviar por padrão : ex  socket,slack  ou só socket ou só slack
-slack: 
+slack:
   slackUrl:
-  #Indica a url do webhook do slack 
+  #Indica a url do webhook do slack
   slackChannel:
   #Indica o canal do slack para ser enviado sempre começando com #
   ```
@@ -322,7 +347,7 @@ slack:
 
 ## Broadcast event com Websocket
 
-O Json Rest server suporta também a comunicação socket para web utilizando websocket, quando você habilita o parâmetro `enableSocket: true` no config você automaticamente está habilitando também o websocket podendo receber socket pelo IO ou Websocket. 
+O Json Rest server suporta também a comunicação socket para web utilizando websocket, quando você habilita o parâmetro `enableSocket: true` no config você automaticamente está habilitando também o websocket podendo receber socket pelo IO ou Websocket.
 
 No websocket a porta de conexão sempre será a mesma do servidor.
 
@@ -337,7 +362,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  
+
   final WebSocketChannel channel = WebSocketChannel.connect(
     Uri.parse('ws://localhost:8080'),
   );
@@ -397,7 +422,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  
+
   final WebSocketChannel channel = WebSocketChannel.connect(
     Uri.parse('ws://localhost:8080?tables=users,products'),
   );
@@ -445,7 +470,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
 Json Rest Server agora da suporte a url de conteúdo (Imagens) estáticas.
 
-Para habilitar o suporte a esse recurso em projetos existentes siga os passos abaixo: 
+Para habilitar o suporte a esse recurso em projetos existentes siga os passos abaixo:
 
 1 - Na raiz do seu projeto, crie uma pasta storage
 2 - Coloque as imagens dentro dessa pasta e agora você terá acesso a url `http://localhost:8080/storage`

--- a/lib/src/core/middlewares/auth_middleware.dart
+++ b/lib/src/core/middlewares/auth_middleware.dart
@@ -66,6 +66,15 @@ class AuthMiddleware extends Middlewares {
 
         for (var u in users) {
           for (var field in authConfig.authFields) {
+            if (!(bodyData as Map).containsKey(field.name)) {
+              return Response(
+                500,
+                body: jsonEncode(
+                    {'error': 'field ${field.name} not found in validation. Please check if you put this validation in config.yaml  then remove it or send the correct fields to authenticate'}),
+                headers: jsonHelper.jsonReturn,
+              );
+            }
+
             dynamic dataAsType;
 
             switch (field.type.toLowerCase()) {

--- a/lib/src/core/middlewares/auth_middleware.dart
+++ b/lib/src/core/middlewares/auth_middleware.dart
@@ -54,15 +54,13 @@ class AuthMiddleware extends Middlewares {
       var user = {};
 
       if (authConfig?.authFields.isEmpty ?? true) {
-        users.firstWhere(
+        user = users.firstWhere(
           (user) {
             return (user['email'] == bodyData['email'] && user['password'] == bodyData['password']);
           },
           orElse: () => {},
         );
-      }
-
-      if (authConfig?.authFields.isNotEmpty ?? false) {
+      } else {
         int numberOfFields = authConfig!.authFields.length;
         int validatedFields = 0;
 

--- a/lib/src/models/config_auth_model.dart
+++ b/lib/src/models/config_auth_model.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-
 import 'package:yaml/yaml.dart';
 
 class ConfigAuthModel {
@@ -8,6 +7,7 @@ class ConfigAuthModel {
   final int unauthorizedStatusCode;
   final bool enableAdm;
   final List<String> urlUserPermission;
+  final List<AuthField> authFields;
   final List<UrlSkip>? urlSkip;
 
   ConfigAuthModel(
@@ -16,6 +16,7 @@ class ConfigAuthModel {
       this.unauthorizedStatusCode = 403,
       this.urlSkip,
       this.urlUserPermission = const <String>[],
+      this.authFields = const <AuthField>[],
       this.enableAdm = false});
 
   Map<String, dynamic> toMap() {
@@ -29,6 +30,7 @@ class ConfigAuthModel {
   factory ConfigAuthModel.fromMap(Map<String, dynamic> map) {
     YamlList? urlSkip = map['urlSkip'];
     YamlList? urlUserPermission = map['urlUserPermission'];
+    YamlList? authFields = map['authFields'];
 
     return ConfigAuthModel(
       jwtSecret: map['jwtSecret'] ?? '',
@@ -36,6 +38,14 @@ class ConfigAuthModel {
       unauthorizedStatusCode: map['unauthorizedStatusCode']?.toInt() ?? 403,
       enableAdm: map['enableAdm'] ?? false,
       urlUserPermission: urlUserPermission?.toList().cast() ?? <String>[],
+      authFields: authFields?.map<AuthField>((element) {
+            var key = element.keys.first;
+            return AuthField(
+              name: key,
+              type: element.value[key]['type'],
+            );
+          }).toList() ??
+          [],
       urlSkip: urlSkip?.map<UrlSkip>(
             (element) {
               var key = element.keys.first;
@@ -51,8 +61,7 @@ class ConfigAuthModel {
 
   String toJson() => json.encode(toMap());
 
-  factory ConfigAuthModel.fromJson(String source) =>
-      ConfigAuthModel.fromMap(json.decode(source));
+  factory ConfigAuthModel.fromJson(String source) => ConfigAuthModel.fromMap(json.decode(source));
 }
 
 class UrlSkip {
@@ -80,6 +89,33 @@ class UrlSkip {
 
   String toJson() => json.encode(toMap());
 
-  factory UrlSkip.fromJson(String source) =>
-      UrlSkip.fromMap(json.decode(source) as Map<String, dynamic>);
+  factory UrlSkip.fromJson(String source) => UrlSkip.fromMap(json.decode(source) as Map<String, dynamic>);
+}
+
+class AuthField {
+  final String name;
+  final String type;
+
+  AuthField({
+    required this.name,
+    required this.type,
+  });
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'name': name,
+      'type': type,
+    };
+  }
+
+  factory AuthField.fromMap(Map<String, dynamic> map) {
+    return AuthField(
+      name: (map['name'] ?? '') as String,
+      type: (map['type'] ?? '') as String,
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  factory AuthField.fromJson(String source) => AuthField.fromMap(json.decode(source) as Map<String, dynamic>);
 }

--- a/test/server/server_config/config.yaml
+++ b/test/server/server_config/config.yaml
@@ -6,7 +6,7 @@ enableSocket: true
 socketPort: 8081
 broadcastProvider: socket #socket,slack  or only socket or only slack
 idType: uuid
-slack: 
+slack:
   slackUrl: '' #your webhook url from slack
   slackChannel: '' #your channel starting with #
 # storage:


### PR DESCRIPTION
Olá @rodrigorahman e @brasizza, espero que vocês estejam bem!

### **Proposta**

Conversei com o Rodrigo sobre a minha ideia, e ele aprovou a proposta, então decidi fazer este PR e venho solicitar que façam uma análise por favor, e qualquer dica que tiverem, ou ajuste necessário, estou disposto a complementar.

A ideia principal dessa implementação, é que o usuário do Json Rest Server tenha a possibilidade de personalizar o método de autenticação e os campos recebidos na request. Atualmente o padrão é "email" e "password", ambos como String.

Me surgiu uma necessidade de fazer um mock de uma API que utiliza CPF, telefone e data de nascimento para fazer a autenticação, com isso surgiu a ideia dessa implementação.

-----

### **Implementação**

No arquivo de configurações ```config.yaml```, criei um novo parâmetro ```authFields```, no qual devem ser passados os campos que serão validados na request de login. Esses campos devem ser passados juntamento com o seu nome + tipo de dado, que podem ser (string, int ou double)

Segue abaixo um exemplo:

```
auth:
  jwtSecret: cwsMXDtuP447WZQ63nM4dWZ3RppyMl
  jwtExpire: 604800

  authFields:
    - documento:
        type: string
    - celular:
        type: int

  urlSkip:
    - /users:
        method: post
```

Como o ```authFields``` é **opcional**, caso o parâmetro não seja definido no *config.yaml*, o JRS manterá a autenticação padrão, que utiliza **"email"** e **"password"**, ambos como string.

### **Considerações Finais**

Conforme falei com o Rodrigo, eu não tive possibilidade de implementar os testes, então isso está pendente. Percebi que não existe testes para quando o Auth está habilitado, então antes de fazer os testes para o authFields, eu teria que implementar os testes de Auth, e estou sem tempo para fazer isso no momento.

Caso consigam me ajudar com os testes, fico agradecido.

Obrigado pela atenção,
Abraço!