### PR TITLE
Mock timeout Http request

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -115,6 +115,15 @@ DELETE /products/1                                  -> Delete a product based on
 
 In the example folder there is a postman file with all the examples above
 
+
+## Timeout test
+In all your HTTP requests now it's possible to interfere with the HTTP request so that you can test a connection timeout, as if it were a server delay. 
+*For it to work, it's necessary to include in the header of your request a field called mock-delay where its value is an integer in seconds.*
+
+ Example:
+
+ ```mock-delay:10```
+
 ## Authentication
 
 Json Rest Server already have all the auth process using JWT.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ DELETE /products/1                                  -> Deletar um produto
 Na pasta exemplos existe um arquivo postman com todos os exemplos mencionados acima
 
 
+## Teste de timeout
+Em todas as suas requisições HTTP agora é possível interferir no request do http para que possa testar um timeout de conexão, como se fosse um delay do servidor.
+*Para o funcionamento é necessário que seja colocado no header da sua reqiusição um campo chamado mock-delay onde o seu valor é um inteiro em segundos*
+Exemplo:
+
+```mock-delay:10```
+
 ## Autenticação
 
 Json Rest Server já vem com todo o processo de autenticação por meio de JWT.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -118,6 +118,12 @@ DELETE /products/1                                  -> Deletar um produto
 
 Na pasta exemplos existe um arquivo postman com todos os exemplos mencionados acima
 
+## Teste de timeout
+Em todas as suas requisições HTTP agora é possível interferir no request do http para que possa testar um timeout de conexão, como se fosse um delay do servidor.
+*Para o funcionamento é necessário que seja colocado no header da sua reqiusição um campo chamado mock-delay onde o seu valor é um inteiro em segundos*
+Exemplo:
+
+```mock-delay:10```
 
 ## Autenticação
 

--- a/lib/src/server/handler_request.dart
+++ b/lib/src/server/handler_request.dart
@@ -30,6 +30,11 @@ class HandlerRequest {
     final Map<String, dynamic>? mapResponse;
 
     try {
+      if (request.headers.keys.contains('mock-delay')) {
+        int delay = int.tryParse(request.headers['mock-delay'].toString()) ?? 0;
+        await Future.delayed(Duration(
+            seconds: delay)); // will wait here until the timeout finish
+      }
       switch (method) {
         case 'GET':
           return GetHandler().execute(request);

--- a/lib/src/server/handlers/get_handler.dart
+++ b/lib/src/server/handlers/get_handler.dart
@@ -83,7 +83,8 @@ class GetHandler {
     }
 
     final result = {
-      ..._databaseRepository.getById(adm ? 'adm_users' : 'users', int.parse(id))
+      ..._databaseRepository.getById(
+          adm ? 'adm_users' : 'users', int.tryParse(id) ?? id)
     };
     result.remove('password');
 

--- a/test/server/handlers/auth_handler_test.dart
+++ b/test/server/handlers/auth_handler_test.dart
@@ -20,8 +20,6 @@ void main() {
     tearDownAll(() => server?.closeServer());
 
     test('Should login success', () async {
-
-
       final Response(
         data: {
           'access_token': accessToken,

--- a/test/server/handlers/me_handler_test.dart
+++ b/test/server/handlers/me_handler_test.dart
@@ -9,7 +9,7 @@ import '../mock/generate_database.dart';
 
 void main() {
   group('Tests get me', () {
-    setUpAll((){
+    setUpAll(() {
       GetIt.I.allowReassignment = true;
     });
     test('Shoud me data when id int', () async {

--- a/test/server/handlers/timeout_handler_test.dart
+++ b/test/server/handlers/timeout_handler_test.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+import 'package:json_rest_server/src/server/json_rest_server.dart';
+import 'package:test/test.dart';
+
+import '../mock/env_mock.dart';
+import '../mock/generate_config.dart';
+import '../mock/generate_database.dart';
+
+void main() {
+  group('Timeout Tests', () {
+    JsonRestServer? server;
+    setUpAll(() async {
+      GenerateDatabase.uuid();
+      GenerateConfig.basic();
+      server = JsonRestServer(EnvMock());
+      await server!.startServer();
+    });
+
+    tearDownAll(() => server?.closeServer());
+    test('sould validate the timeout exception ', () async {
+      try {
+        await Dio(BaseOptions(receiveTimeout: Duration(seconds: 3))).get(
+            'http://localhost:8080/users',
+            options: Options(headers: {'mock-delay': 10}));
+      } on DioException catch (e) {
+        expect(e.type, DioExceptionType.receiveTimeout);
+      }
+    });
+  });
+}

--- a/test/server/mock/env_mock.dart
+++ b/test/server/mock/env_mock.dart
@@ -18,10 +18,10 @@ class EnvMockAuth extends Env {
   factory EnvMockAuth.defaultAuth() {
     // Substituir o arquivo pelo template do config_defaults.yaml
     final basePath = path.joinAll([path.current, 'test', 'server', 'mock']);
-    
+
     final jsonConfig =
         File(path.joinAll([basePath, 'auth_default_config.json']));
-    var yamlWriter = YamlWriter(allowUnquotedStrings:true);
+    var yamlWriter = YamlWriter(allowUnquotedStrings: true);
     var yamlDoc = yamlWriter.write(jsonDecode(jsonConfig.readAsStringSync()));
     print(yamlDoc);
     final finalFile = File(path.joinAll([basePath, 'config.yaml']));

--- a/test/server/mock/generate_config.dart
+++ b/test/server/mock/generate_config.dart
@@ -10,16 +10,14 @@ class GenerateConfig {
 
   static void basic() => _generateConfig('basic_config.json');
   static void defaultAuth() => _generateConfig('auth_default_config.json');
-  static void defaultAuthIntId() => _generateConfig('auth_default_id_int_config.json');
+  static void defaultAuthIntId() =>
+      _generateConfig('auth_default_id_int_config.json');
 
   static void customFieldsAuth() =>
       _generateConfig('auth_custom_fields_config.json');
 
-
   static void defaultAuthIdInt() =>
       _generateConfig('auth_default_id_int_config.json');
-
-
 
   static void _generateConfig(String mockFile) {
     final jsonConfig = File(path.joinAll([_basePath, 'mock', mockFile]));

--- a/test/server/mock/generate_database.dart
+++ b/test/server/mock/generate_database.dart
@@ -9,7 +9,6 @@ class GenerateDatabase {
   static void uuid() => _generateConfig('database_uuid.json');
   static void int() => _generateConfig('database_int.json');
 
-
   static void _generateConfig(String mockFile) {
     final jsonConfig = File(path.joinAll([_basePath, 'mock', mockFile]));
     final finalFile =

--- a/test/server/server_config/config.yaml
+++ b/test/server/server_config/config.yaml
@@ -6,6 +6,3 @@ enableSocket: true
 socketPort: 8081
 broadcastProvider: socket
 idType: uuid
-auth: 
-  jwtSecret: cwsMXDtuP447WZQ63nM4dWZ3RppyMl
-  jwtExpire: 3600


### PR DESCRIPTION
Criação de um campo apra manipular o timeout do servidor

Foi criado um campo no header chamado **mock-delay** para que possa ser feito um atraso de conexão para testar com internet mais fraca e testar o try/catch para falha de conexão